### PR TITLE
Fixes QueryBuilder eager() bug where named eager filters cause errors

### DIFF
--- a/src/QueryBuilder.js
+++ b/src/QueryBuilder.js
@@ -74,7 +74,7 @@ export class QueryBuilder extends ObjectionQueryBuilder {
 			return this
 		}
 
-		if(!exp.isNil) {
+		if(typeof exp === 'string') {
 			filters = Object.assign({ }, this.constructor.registeredFilters, filters || { })
 		}
 


### PR DESCRIPTION
Fixes: using any named eager-filter throws an error due to the filter not being found

This bug occurs because `QueryBuilder.registeredFilters` is always being set to an `object`, even when it should be `undefined`.

By default, `QueryBuilder.merge()` is called twice for each query. The bug occurs during the second call.
In the first call, `exp` is a string. This is when all eager filters should be set.
In the second call, `exp` is an instance of `RelationExpression`.  Eager filters should not be reset here because, in this second call, QueryBuilder has lost its reference to named filters - accounting for the thrown errors. 
In this second call, the `filters` parameter should be `undefined` (its default value), in which case filters do not change from the first call and everything works.

The issue is caused because, in the second call, `filters` is reset to equal `QueryBuilder.registeredFilter` (even if there are no registered filters, it's still an empty object), thus overriding and losing all reference to the original named eager filters.

The fix is to set `filters` only when `typeof exp === 'string'` i.e. only in the first call.