### PR TITLE
Add option to retain patch/update identifier safety in objection 0.7.0

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -15,6 +15,7 @@ export class Model extends ObjectionModel {
 	static createdAt = 'created_at'
 	static updatedAt = 'updated_at'
 	static dates = [ ]
+	static useIdSafeUpdates = false
 
 	static $$app = null
 
@@ -265,6 +266,18 @@ export class Model extends ObjectionModel {
 	}
 
 	$beforeUpdate() {
+		if(this.constructor.useIdSafeUpdates) {
+			const cols = this.constructor.getIdColumnArray()
+
+			if(cols.length === 1) {
+				delete this[cols[0]]
+			} else {
+				for(let i = 0, l = cols.length; i < l; i++) {
+					delete this[cols[i]]
+				}
+			}
+		}
+
 		return this.$beforeSave(false)
 	}
 


### PR DESCRIPTION
**Addresses:** This PR assumes that at some point grind-orm will upgrade to objection 0.7.*.
One of the breaking changes with 0.7.0 is that patch/update operations can now change identifier columns. In other words, the `id` column can be changed accidentally. Previously, if an `id` column was in a patch/update operation it was ignored. 

This safety feature seems useful as it's generally considered bad practice to change a model's identifier, so cases when this happens will often be unintentional and destructive.

This PR adds a non-default option to preserve the patch/update safety feature. At the same time, it remains compatible with grind-orm using objection 0.6.* (i.e. it doesn't add extra overhead).

**Changes:** adds a new static variable to Model called `useIdSafeUpdates`, which defaults to `false`. When set to true, ID columns will be stripped from patch/update queries using objection's previously included logic. 

Ex. 
```
import { Model } from 'grind-orm'

Model.useIdSafeUpdates = true
```

Since the default for `useIdSafeUpdates` is `false`, it is compatible with 0.6.*, where identifier safety is already default behavior so setting `useIdSafeUpdates`  is unnecessary. Once using objection 0.7.0, setting it to `true` will preserve the previous safety behavior.